### PR TITLE
Fix maxResults

### DIFF
--- a/js/genetic-0.1.14.js
+++ b/js/genetic-0.1.14.js
@@ -153,14 +153,14 @@ var Genetic = Genetic || (function(){
 					, "stdev": stdev
 				};
 
-				var r = this.generation ? this.generation(pop, i, stats) : true;
+				var r = this.generation ? this.generation(pop.slice(0, this.configuration["maxResults"]), i, stats) : true;
 				var isFinished = (typeof r != "undefined" && !r) || (i == this.configuration.iterations-1);
 				
 				if (
 					this.notification
 					&& (isFinished || this.configuration["skip"] == 0 || i%this.configuration["skip"] == 0)
 				) {
-					this.sendNotification(pop.slice(0, this.maxResults), i, stats, isFinished);
+					this.sendNotification(pop.slice(0, this.configuration["maxResults"]), i, stats, isFinished);
 				}
 					
 				if (isFinished)


### PR DESCRIPTION
The parameter `configuration['maxResults']` wasn't taken into account at all.